### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM golang:latest 
-RUN mkdir /app 
-ADD . /app/ 
-WORKDIR /app 
-RUN go build -o main . 
-CMD ["/app/main"]
+FROM golang:latest
+
+WORKDIR /go/src/flow-debugproxy
+COPY . .
+
+RUN go get -v
+RUN go install -v
+
+CMD ["flow-debugproxy"]


### PR DESCRIPTION
Using the old Dockerfile the build errored with:
```
latest: Pulling from library/golang
Digest: sha256:957f390aceead48668eb103ef162452c6dae25042ba9c41762f5210c5ad3aeea
Status: Downloaded newer image for golang:latest
 ---> d0e7a411e3da
Step 2/6 : RUN mkdir /app
 ---> Running in b99dcccb9b94
Removing intermediate container b99dcccb9b94
 ---> 037a6bd5a18b
Step 3/6 : ADD . /app/
 ---> 38109680fb9c
Step 4/6 : WORKDIR /app
 ---> Running in e66dc643fc86
Removing intermediate container e66dc643fc86
 ---> 417df0d9cd53
Step 5/6 : RUN go build -o main .
 ---> Running in d75d750cf436
main.go:20:2: cannot find package "github.com/codegangsta/cli" in any of:
	/usr/local/go/src/github.com/codegangsta/cli (from $GOROOT)
	/go/src/github.com/codegangsta/cli (from $GOPATH)
main.go:8:2: cannot find package "github.com/dfeyer/flow-debugproxy/config" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/config (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/config (from $GOPATH)
main.go:17:2: cannot find package "github.com/dfeyer/flow-debugproxy/dummypathmapper" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/dummypathmapper (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/dummypathmapper (from $GOPATH)
main.go:10:2: cannot find package "github.com/dfeyer/flow-debugproxy/errorhandler" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/errorhandler (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/errorhandler (from $GOPATH)
main.go:18:2: cannot find package "github.com/dfeyer/flow-debugproxy/flowpathmapper" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/flowpathmapper (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/flowpathmapper (from $GOPATH)
main.go:11:2: cannot find package "github.com/dfeyer/flow-debugproxy/logger" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/logger (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/logger (from $GOPATH)
main.go:12:2: cannot find package "github.com/dfeyer/flow-debugproxy/pathmapperfactory" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/pathmapperfactory (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/pathmapperfactory (from $GOPATH)
main.go:13:2: cannot find package "github.com/dfeyer/flow-debugproxy/pathmapping" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/pathmapping (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/pathmapping (from $GOPATH)
main.go:14:2: cannot find package "github.com/dfeyer/flow-debugproxy/xdebugproxy" in any of:
	/usr/local/go/src/github.com/dfeyer/flow-debugproxy/xdebugproxy (from $GOROOT)
	/go/src/github.com/dfeyer/flow-debugproxy/xdebugproxy (from $GOPATH)
```

Using the new build method as described in https://hub.docker.com/_/golang/