### PR TITLE
TASK: Make the CMD the ENTRYPOINT to pass arguments without command repetition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY . .
 RUN go get -v
 RUN go install -v
 
-CMD ["flow-debugproxy"]
+ENTRYPOINT ["flow-debugproxy"]


### PR DESCRIPTION
When "flow-debugproxy" is the command and you ant to pass `--xdebug 0.0.0.0:9002` as an argument you have to write `docker run image flow-debugproxy --xdebug 0.0.0.0:9002` because the argument will overwrite CMD.
When flow-debugproxy is the ENTRYPOINT the argument will just be appended so you can write `docker run image --xdebug 0.0.0.0:9002`